### PR TITLE
Update NewsApi.php

### DIFF
--- a/src/NewsApi.php
+++ b/src/NewsApi.php
@@ -116,7 +116,7 @@ class NewsApi
 
 		//Add SortBy if provided
 		if (!is_null($sort_by)) {
-			if (Helpers::isLanguageValid($sort_by)) { $payload['sortBy'] = $sort_by; }
+			if (Helpers::isSortByValid($sort_by)) { $payload['sortBy'] = $sort_by; }
 			else {throw new NewsApiException("Invalid SortBy Identifier Provided "); }
 		}
 


### PR DESCRIPTION
Error when try to sort by because was checking the valid type of sort  in the language array.
Fixed
Maybe because a typo error or copy / paste at moment of check if the sort By was valid it was comparing with languages instead of sortBy array. 