### PR TITLE
Newer versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "6 - 7"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.*"
+        "phpunit/phpunit": "6 - 9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allow newer versions of guzzle and phpunit dependencies.

guzzlehttp/guzzle: ~6.0 -> 6 - 7
phpunit/phpunit: 6.* -> 6 - 9

I've tested these versions of newer dependencies and they still work(the api was not changed).